### PR TITLE
Build, test and deploy with AppVeyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains Chocolatey Package Manager definitions for
 
 [![Latest version released](https://img.shields.io/chocolatey/v/docker.svg)](https://chocolatey.org/packages/docker)
 [![Package downloads count](https://img.shields.io/chocolatey/dt/docker.svg)](https://chocolatey.org/packages/docker)
+[![Build status](https://ci.appveyor.com/api/projects/status/yrojei8f42a8enpg/branch/master?svg=true)](https://ci.appveyor.com/project/ahmetalpbalkan/docker-chocolatey/branch/master)
 
 Chocolatey releases for Docker are not done nor supported by Docker, Inc.
 This package is maintained by the community members.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+version: 1.9.0.{build}
+environment:
+  TOKEN:
+    secure: YOUR-ENCRYPTED-CHOCO-APIKEY
+
+build_script:
+  - ps: cpack
+
+test_script:
+  - ps: .\test.ps1
+
+deploy_script:
+  - ps: >-
+      Write-Host $env:APPVEYOR_REPO_TAG ;
+      if($env:APPVEYOR_REPO_BRANCH -eq 'master' -And $env:APPVEYOR_REPO_TAG -eq 'true') {
+        $version = $env:APPVEYOR_BUILD_VERSION -replace('\.[^.\\/]+$') ;
+        choco apiKey -k $env:TOKEN -source https://chocolatey.org/ ;
+        choco push docker.$version.nupkg
+      }
+
+artifacts:
+  - path: '**\*.nupkg'
+    name: Package

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,8 @@ build_script:
   - ps: cpack
 
 test_script:
-  - ps: .\test.ps1
+  - ps: .\test.ps1 -cpu x64
+  - ps: .\test.ps1 -cpu x86
 
 deploy_script:
   - ps: >-

--- a/test.ps1
+++ b/test.ps1
@@ -1,0 +1,37 @@
+"Running tests"
+$ErrorActionPreference = "Stop"
+$version = $env:APPVEYOR_BUILD_VERSION -replace('\.[^.\\/]+$')
+
+"TEST: Version $version in docker.nuspec file should match"
+[xml]$spec = Get-Content docker.nuspec
+if ($spec.package.metadata.version.CompareTo($version)) {
+  Write-Error "FAIL: rong version in nuspec file!"
+}
+
+"TEST: Package should contain only install script"
+Add-Type -assembly "system.io.compression.filesystem"
+$zip = [IO.Compression.ZipFile]::OpenRead("$pwd\docker.$version.nupkg")
+if ($zip.Entries.Count -ne 5) {
+  Write-Error "FAIL: Wrong count in nupkg!"
+}
+$zip.Dispose()
+
+"TEST: Installation of package should work"
+. choco install -y docker -source .
+
+"TEST: Version of binary should match"
+. docker --version
+if (-Not $(docker --version).Contains("version $version,")) {
+  Write-Error "FAIL: Wrong version of docker installed!"
+}
+
+"TEST: Uninstall show remove the binary"
+. choco uninstall docker
+try {
+  . docker
+  Write-Error "FAIL: docker binary still found"
+} catch {
+  Write-Host "PASS: docker not found"
+}
+
+"TEST: Finished"


### PR DESCRIPTION
@ahmetalpbalkan To make things faster for the next release, I send you my current setup how I build, test and deploy the Chocolatey packages for `docker-machine` and `docker-compose`.

This PR uses AppVeyor to build the choco package, then installs it, runs some tests with the docker.exe and also checks the uninstall.

After pushing a new tag to GitHub the choco package can be pushed to Chocolatey with an encrypted environment with the Chocolatey API key.

See also:
- https://github.com/StefanScherer/choco-docker-compose
- https://github.com/silarsis/choco-docker-machine
