### PR TITLE
Update docker 1.11.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.11.0.{build}
+version: 1.11.1.{build}
 environment:
   TOKEN:
     secure: KE3DuBSMhbBxLurkOXLrmAFbF+zptuCJztv1LDq1DfU65A1NSoYTI9JpYE63h/66

--- a/docker.nuspec
+++ b/docker.nuspec
@@ -5,7 +5,7 @@
     <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>docker</id>
     <title>Docker</title>
-    <version>1.11.0</version>
+    <version>1.11.1</version>
     <authors>Docker Contributors</authors>
     <owners>ahmetalpbalkan</owners>
     <summary>Docker is an open platform for developers and sysadmins to build, ship, and run distributed applications.</summary>

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,8 +1,8 @@
 $packageName    = 'docker'
-$url            = 'https://get.docker.com/builds/Windows/i386/docker-1.11.0.zip'
-$checksum       = 'f8bbf3bd40c9939513f5023f5107e9b2'
-$url64          = 'https://get.docker.com/builds/Windows/x86_64/docker-1.11.0.zip'
-$checksum64     = '1474613540062ba4d28496e060da5e15'
+$url            = 'https://get.docker.com/builds/Windows/i386/docker-1.11.1.zip'
+$checksum       = '9f70c194a760a6f339b51ddc84f5c16d'
+$url64          = 'https://get.docker.com/builds/Windows/x86_64/docker-1.11.1.zip'
+$checksum64     = '2148235257bd34b11da6bccb926d807b'
 $checksumType   = 'md5'
 $checksumType64 = 'md5'
 $validExitCodes = @(0)


### PR DESCRIPTION
I've got a mail from Sibbell that Docker 1.11.1 has been released (tagged on GitHub)
So I ran `./update.sh 1.11.1` and created this PR.

Signed-off-by: Stefan Scherer scherer_stefan@icloud.com
