### PR TITLE
Allow update.sh to work with Windows Subsystem for Linux

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -7,7 +7,7 @@ if [ "$1" = "" ]; then
   exit 1
 fi
 
-if [[ "${OSTYPE}" != "darwin"* ]]; then
+if [[ "${OSTYPE}" != "darwin"* && "${OSTYPE}" != "linux-gnu"* ]]; then
   echo "This version does only support Mac."
   exit 2
 fi

--- a/update.sh
+++ b/update.sh
@@ -8,7 +8,7 @@ if [ "$1" = "" ]; then
 fi
 
 if [[ "${OSTYPE}" != "darwin"* && "${OSTYPE}" != "linux-gnu"* ]]; then
-  echo "This version does only support Mac."
+  echo "This version support Mac and Windows Subsystem for Linux"
   exit 2
 fi
 


### PR DESCRIPTION
This PR allows Windows users to run update.sh in Windows Subsystem for Linux.