### PR TITLE
Add more metadata

### DIFF
--- a/docker.nuspec
+++ b/docker.nuspec
@@ -11,10 +11,14 @@
     <summary>Docker is an open platform for developers and sysadmins to build, ship, and run distributed applications.</summary>
     <description>Docker is an open platform for developers and sysadmins to build, ship, and run distributed applications. This package contains the docker client for Windows and not the Docker engine to run containers on Windows hosts.
 
-NOTE: Docker client for Windows is not a Docker container engine for Windows. You can use this to manage your Linux machines running as Docker hosts at the moment until the containers support comes out in the next version of Windows Server.</description>
+NOTE: Docker client for Windows is not a Docker container engine for Windows. You can use this to manage your Linux and Windows machines running as Docker hosts. You might want to have a look at the "docker-for-windows" package.</description>
     <projectUrl>https://www.docker.com</projectUrl>
+    <projectSourceUrl>https://github.com/docker/docker</projectSourceUrl>
     <tags>docker devops containers</tags>
     <copyright></copyright>
+    <docsUrl>https://docs.docker.com/engine/getstarted/</docsUrl>
+    <bugTrackerUrl>https://github.com/docker/docker/issues</bugTrackerUrl>
+    <mailingListUrl>https://github.com/docker/docker#talking-to-other-docker-users-and-contributors</mailingListUrl>
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://cdn.rawgit.com/ahmetalpbalkan/docker-chocolatey/d9d3bd5a750d03fc8933e1bee4c3755f361e2797/docker.png</iconUrl>


### PR DESCRIPTION
AppVeyor makes it too easy to deploy new choco packages. So I haven't seen the suggestions of the last reviews. Here are some more metadata to fill the Chocolatey package gallery even better.
