### PR TITLE
Adjust download uri for release candidates

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -14,8 +14,15 @@ fi
 
 version=$1
 
-url="https://get.docker.com/builds/Windows/i386/docker-${version}.zip"
-url64="https://get.docker.com/builds/Windows/x86_64/docker-${version}.zip"
+uri="get"
+
+if [[ $version = *"-rc"* ]]
+then
+  uri="test"
+fi
+
+url="https://${uri}.docker.com/builds/Windows/i386/docker-${version}.zip"
+url64="https://${uri}.docker.com/builds/Windows/x86_64/docker-${version}.zip"
 checksum=$(curl "${url}.md5" | cut -f 1 -d " ")
 checksum64=$(curl "${url64}.md5" | cut -f 1 -d " ")
 


### PR DESCRIPTION
The download url for release candidate binary is now ```test.docker.com/...``` . This PR enable update.sh script to download RC binary from adjusted uri. The script was tested on Windows subsystem for linux. The problem was found while I trying to create run ```./update.sh 1.13.0-rc3``` which ended up error as curl trid to download binary from wrong url.