### PR TITLE
Switch to sha256 checksums

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: 1.13.1.{build}
 environment:
   TOKEN:
-    secure: KE3DuBSMhbBxLurkOXLrmAFbF+zptuCJztv1LDq1DfU65A1NSoYTI9JpYE63h/66
+    secure: TihxnYdIwtxnhS568XO7PECa6ETPBcTk2fUSgO8wq60c75Io9xPXE3TtLCBf5D6h
 
 build_script:
   - ps: choco pack

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,10 +1,10 @@
 $packageName    = 'docker'
 $url            = 'https://get.docker.com/builds/Windows/i386/docker-1.13.1.zip'
-$checksum       = '1731804d28081b35751523136a31cfbf'
+$checksum       = '3e31c57b0e592c5a9a489cd779c5564413c8510cfdc0b9404269623a7f6cba44'
 $url64          = 'https://get.docker.com/builds/Windows/x86_64/docker-1.13.1.zip'
-$checksum64     = '520a2c6a98c811da7064e78e7000b3b7'
-$checksumType   = 'md5'
-$checksumType64 = 'md5'
+$checksum64     = '850deeac9e05a2426be335b7bf4b31757c98639eb35e0fe8d9c4b1dc8cc06c38'
+$checksumType   = 'sha256'
+$checksumType64 = 'sha256'
 $validExitCodes = @(0)
 
 $toolsDir    = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"

--- a/update.sh
+++ b/update.sh
@@ -23,8 +23,8 @@ fi
 
 url="https://${uri}.docker.com/builds/Windows/i386/docker-${version}.zip"
 url64="https://${uri}.docker.com/builds/Windows/x86_64/docker-${version}.zip"
-checksum=$(curl "${url}.md5" | cut -f 1 -d " ")
-checksum64=$(curl "${url64}.md5" | cut -f 1 -d " ")
+checksum=$(curl "${url}.sha256" | cut -f 1 -d " ")
+checksum64=$(curl "${url64}.sha256" | cut -f 1 -d " ")
 
 sed -i.bak "s/<version>.*<\/version>/<version>${version}<\/version>/" docker.nuspec
 


### PR DESCRIPTION
Just a preparation for the next releases and trigger a build in AppVeyor to check if it still works, I switch from md5 to sha256 checksums.
