### PR TITLE
Update TOKEN and switch to sha256

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: 17.03.0-ce-rc1.{build}
 environment:
   TOKEN:
-    secure: KE3DuBSMhbBxLurkOXLrmAFbF+zptuCJztv1LDq1DfU65A1NSoYTI9JpYE63h/66
+    secure: TihxnYdIwtxnhS568XO7PECa6ETPBcTk2fUSgO8wq60c75Io9xPXE3TtLCBf5D6h
 
 build_script:
   - ps: choco pack

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,10 +1,10 @@
 $packageName    = 'docker'
 $url            = 'https://test.docker.com/builds/Windows/i386/docker-17.03.0-ce-rc1.zip'
-$checksum       = 'eeb278fd066bfc7bb97ec1b551e14ba5'
+$checksum       = '5a38233d28ea20d1b382d8217a4ef0f1aa11fb9b0ce15a042128eed749c803f4'
 $url64          = 'https://test.docker.com/builds/Windows/x86_64/docker-17.03.0-ce-rc1.zip'
-$checksum64     = '2dc3f2d76a77a338035770d602a0634d'
-$checksumType   = 'md5'
-$checksumType64 = 'md5'
+$checksum64     = '0f5d1a6c60011e9cb5ab75b6c70e14495dad8957a3aacb1a6e76d54e011b71d0'
+$checksumType   = 'sha256'
+$checksumType64 = 'sha256'
 $validExitCodes = @(0)
 
 $toolsDir    = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"

--- a/update.sh
+++ b/update.sh
@@ -23,8 +23,8 @@ fi
 
 url="https://${uri}.docker.com/builds/Windows/i386/docker-${version}.zip"
 url64="https://${uri}.docker.com/builds/Windows/x86_64/docker-${version}.zip"
-checksum=$(curl "${url}.md5" | cut -f 1 -d " ")
-checksum64=$(curl "${url64}.md5" | cut -f 1 -d " ")
+checksum=$(curl "${url}.sha256" | cut -f 1 -d " ")
+checksum64=$(curl "${url64}.sha256" | cut -f 1 -d " ")
 
 sed -i.bak "s/<version>.*<\/version>/<version>${version}<\/version>/" docker.nuspec
 


### PR DESCRIPTION
Preparation steps for next release candidate. 
Switch to SHA256 checksums, update Token after #36 
