### PR TITLE
Update docker 17.06.0 ce

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,15 +1,15 @@
 # Maintainer's Guide
 
 This document explains how to maintain Chocolatey package
-for Docker client for Windows.
+for Docker CE client for Windows.
 
 ## How it works
 
-This Chocolatey package is designed to download the docker
-client binary (.exe) from `get.docker.com` and place it
+This Chocolatey package is designed to download the Docker CE
+client binary (.exe) from `download.docker.com/win/static/edge` and place it
 in `%PATH%`.
 
-The pre-release packages download the docker client binary from `test.docker.com`.
+The pre-release packages download the docker client binary from `download.docker.com/win/static/test`.
 
 Main installation script is written in PowerShell and is in
 `tools\chocolateyInstall.ps1`.
@@ -21,7 +21,7 @@ Main installation script is written in PowerShell and is in
 ## Making a new release
 
 The following steps describe the process to make a new release. If you want
-to make a new pre-release eg. for a release candidate 1.12.0-rc5, see the steps below.
+to make a new pre-release eg. for a release candidate 17.06.0-ce-rc5, see the steps below.
 
 #### 1. Update all files
 
@@ -30,7 +30,7 @@ First make sure you are in the `master` branch.
     git checkout master
     git pull
 
-Run `./update.sh 1.10.3` and specify the new version of the Docker client. (The script works on Mac only at the moment).
+Run `./update.sh 17.06.0-ce` and specify the new version of the Docker client. (The script works on Mac only at the moment).
 This will update these files
   * docker.nuspec
   * appveyor.yml
@@ -40,9 +40,9 @@ This will update these files
 
 Create a branch and push it.
 
-    git checkout -b update-docker-1.10.3
+    git checkout -b update-docker-17.06.0-ce
     git add docker.nuspec appveyor.yml tools/chocolateyInstall.ps1
-    git push -u origin update-docker-1.10.3
+    git push -u origin update-docker-17.06.0-ce
 
 #### 3. Create a pull request
 
@@ -55,7 +55,7 @@ At GitHub merge the pull request if all the tests from AppVeyor are green.
 #### 5. Draft a release
 
 Now draft a new release at https://github.com/ahmetalpbalkan/docker-chocolatey/releases/new
-Enter eg. 1.10.3 in the field "Tag version" and "Release title" and add some nice description.
+Enter eg. 17.06.0-ce in the field "Tag version" and "Release title" and add some nice description.
 
 AppVeyor then builds the package again, tests it and then pushes it to Chocolatey for approval.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 17.05.0.{build}
+version: 17.06.0.{build}
 environment:
   TOKEN:
     secure: TihxnYdIwtxnhS568XO7PECa6ETPBcTk2fUSgO8wq60c75Io9xPXE3TtLCBf5D6h
@@ -7,8 +7,7 @@ build_script:
   - ps: choco pack
 
 test_script:
-  - ps: .\test.ps1 -cpu x64
-  - ps: .\test.ps1 -cpu x86
+  - ps: .\test.ps1
 
 deploy_script:
   - ps: >-

--- a/docker.nuspec
+++ b/docker.nuspec
@@ -5,7 +5,7 @@
     <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>docker</id>
     <title>Docker</title>
-    <version>17.05.0</version>
+    <version>17.06.0</version>
     <authors>Docker Contributors</authors>
     <owners>ahmetalpbalkan</owners>
     <summary>Docker is an open platform for developers and sysadmins to build, ship, and run distributed applications.</summary>

--- a/test.ps1
+++ b/test.ps1
@@ -1,15 +1,3 @@
-param(
-  [string]$cpu
-)
-
-if (!$cpu) {
-  $cpu = "x64"
-}
-if ($cpu -eq "x86") {
-  $options = "-forcex86"
-}
-
-"Running tests for $cpu"
 $ErrorActionPreference = "Stop"
 
 if ($env:APPVEYOR_BUILD_VERSION) {
@@ -36,7 +24,7 @@ if ($zip.Entries.Count -ne 7) {
 $zip.Dispose()
 
 "TEST: Installation of package should work"
-. choco install -y docker $options -source .
+. choco install -y docker -source .
 
 "TEST: Version of binary should match"
 . docker --version

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Build and test the docker NuGet package in a Windows container
+
+docker build -t chocolatey - <<EOF
+FROM microsoft/windowsservercore
+
+ENV chocolateyUseWindowsCompression false
+
+RUN powershell -Command \
+    iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'));
+EOF
+
+docker run --rm -v C:$(pwd):C:/package -w C:/package chocolatey powershell -Command 'cpack ; .\test.ps1'

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,8 +1,8 @@
 $packageName    = 'docker'
-$url            = 'https://get.docker.com/builds/Windows/i386/docker-17.05.0-ce.zip'
-$checksum       = '99820746a362466700718d33ee727b9aea993b9c2e05fb2c53ed606e9f6780f1'
-$url64          = 'https://get.docker.com/builds/Windows/x86_64/docker-17.05.0-ce.zip'
-$checksum64     = 'cbb0b47b511023a98dd0c83d76c1f30b315b8381b85b67be355eca4748229031'
+$url            = 'https://download.docker.com/win/static/edge/x86_64/docker-17.06.0-ce.zip'
+$checksum       = '3d27360a11a3a627aac9c6d73eb32d4a9b6dcca6bcb4b2c7a5fcd9d2e0ec6c82'
+$url64          = $url
+$checksum64     = $checksum
 $checksumType   = 'sha256'
 $checksumType64 = 'sha256'
 $validExitCodes = @(0)

--- a/update.sh
+++ b/update.sh
@@ -3,7 +3,7 @@
 if [ "$1" = "" ]; then
   echo "Usage: $0 version"
   echo "Update the choco package to a given version"
-  echo "Example: $0 17.03.0-ce"
+  echo "Example: $0 17.06.0-ce"
   exit 1
 fi
 
@@ -14,20 +14,18 @@ fi
 
 version=$1
 
-uri="get"
+uri="edge"
 
 if [[ $version = *"-rc"* ]]
 then
   uri="test"
 fi
 
-# cut off "-ce"
-version=${version//-ce/}
+url="https://download.docker.com/win/static/${uri}/x86_64/docker-${version}.zip"
+checksum=$(curl "${url}" | shasum -a 256 | cut -f 1 -d " ")
 
-url="https://${uri}.docker.com/builds/Windows/i386/docker-${version}-ce.zip"
-url64="https://${uri}.docker.com/builds/Windows/x86_64/docker-${version}-ce.zip"
-checksum=$(curl "${url}.sha256" | cut -f 1 -d " ")
-checksum64=$(curl "${url64}.sha256" | cut -f 1 -d " ")
+# cut off "-ce", eg. 17.06.0-ce -> 17.06.0
+version=${version//-ce/}
 
 sed -i.bak "s/<version>.*<\/version>/<version>${version}<\/version>/" docker.nuspec
 


### PR DESCRIPTION
* Update to new download location download.docker.com/win/static/edge
* No 32bit binaries available, 64bit only
* Add `test.sh` to build and test the choco package in a Windows container before sending a PR.


