### PR TITLE
Use docker cli builder releases

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 17.10.0.{build}
+version: 18.06.0.{build}
 environment:
   TOKEN:
     secure: TihxnYdIwtxnhS568XO7PECa6ETPBcTk2fUSgO8wq60c75Io9xPXE3TtLCBf5D6h

--- a/docker.nuspec
+++ b/docker.nuspec
@@ -5,7 +5,7 @@
     <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>docker</id>
     <title>Docker</title>
-    <version>17.10.0</version>
+    <version>18.06.0</version>
     <authors>Docker Contributors</authors>
     <owners>ahmetalpbalkan</owners>
     <summary>Docker is an open platform for developers and sysadmins to build, ship, and run distributed applications.</summary>

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,6 +1,6 @@
 $packageName    = 'docker'
-$url            = 'https://download.docker.com/win/static/edge/x86_64/docker-17.10.0-ce.zip'
-$checksum       = 'd69fac0f201b6f5727e0985990261ddc4e1cb3edd1f8db4ff46f3b2c59c3b873'
+$url            = 'https://github.com/StefanScherer/docker-cli-builder/releases/download/18.06.0-ce/docker.exe'
+$checksum       = '8ac7d299e6bbbd4af74ac28d930875bf9e1630a6a618b29734afdaea158edea4'
 $url64          = $url
 $checksum64     = $checksum
 $checksumType   = 'sha256'

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,6 +1,6 @@
 $packageName    = 'docker'
 $url            = 'https://github.com/StefanScherer/docker-cli-builder/releases/download/18.06.0-ce/docker.exe'
-$checksum       = '8ac7d299e6bbbd4af74ac28d930875bf9e1630a6a618b29734afdaea158edea4'
+$checksum       = 'd69fac0f201b6f5727e0985990261ddc4e1cb3edd1f8db4ff46f3b2c59c3b873'
 $url64          = $url
 $checksum64     = $checksum
 $checksumType   = 'sha256'
@@ -9,5 +9,8 @@ $validExitCodes = @(0)
 
 $toolsDir    = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
-Install-ChocolateyZipPackage "docker" "$url" "$toolsDir" "$url64" `
- -checksum $checksum -checksumType $checksumType -checksum64 $checksum64 -checksumType64 $checksumType64
+$file = "$($toolsDir)\docker.exe"
+
+if (![System.IO.Directory]::Exists($toolsDir)) {[System.IO.Directory]::CreateDirectory($toolsDir)}
+
+Get-ChocolateyWebFile $packageName $file $url $url64 $checksum $checksum64 $checksumType $checksumType64

--- a/update.sh
+++ b/update.sh
@@ -21,8 +21,8 @@ then
   uri="test"
 fi
 
-url="https://download.docker.com/win/static/${uri}/x86_64/docker-${version}.zip"
-checksum=$(curl "${url}" | shasum -a 256 | cut -f 1 -d " ")
+url="https://github.com/StefanScherer/docker-cli-builder/releases/download/${version}/docker.exe"
+checksum=$(curl -L "${url}" | shasum -a 256 | cut -f 1 -d " ")
 
 # cut off "-ce", eg. 17.06.0-ce -> 17.06.0
 version=${version//-ce/}


### PR DESCRIPTION
To update to newer versions of Docker CLI I have created a small build pipeline to compile Docker CLI from source repo https://github.com/docker/cli with an AppVeyor YML https://github.com/StefanScherer/docker-cli-builder/blob/master/appveyor.yml and deploy it to GitHub releases https://github.com/StefanScherer/docker-cli-builder/releases

Looks like the docker/cli finally gets some tags starting with 18.06.0-ce.
