### PR TITLE
Rename title to Docker CLI

### DIFF
--- a/docker.nuspec
+++ b/docker.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>docker</id>
-    <title>Docker</title>
+    <title>Docker CLI</title>
     <version>18.06.1</version>
     <authors>Docker Contributors</authors>
     <owners>ahmetalpbalkan</owners>


### PR DESCRIPTION
Rename the title of the package from "Docker" to "Docker CLI".
The package name is still docker.
